### PR TITLE
Add xboxdrv Compile Time For Pi Zero 2

### DIFF
--- a/Controls_Updater_Menu.md
+++ b/Controls_Updater_Menu.md
@@ -15,7 +15,7 @@ command prompt.
 
 * pi@retropie:~ $  sudo ./RetroPie-Setup/retropie_setup.sh [enter]
 * go to manage packages, driver, xboxdrv, install from source.
-  * It takes 1 hour 15 mins to compile.
+  * It takes 1 hour 15 mins to compile on a raspberry pi zero(w) & 20minutes on a raspberry pi zero 2.
 
 * Exit the setup menu.
 


### PR DESCRIPTION
Adds the Compile Time for xboxdrv on a Raspberry Pi Zero 2 To The Advance Controller Framework Install Guide(Controls_Updater_Menu.md)